### PR TITLE
Improve CLI parsing of plugins options

### DIFF
--- a/fps/logging.py
+++ b/fps/logging.py
@@ -10,6 +10,8 @@ from typing import Dict, Optional, Union
 
 import click
 
+from fps.utils import merge_dicts
+
 TRACE_LOG_LEVEL = 5
 LOG_CONFIG: Dict[str, Union[str, int, float]] = dict()
 
@@ -137,26 +139,6 @@ def colourized_formatter(
         return logging.Formatter(fmt)
 
 
-def merge_configs(a, b, path=None):
-    if path is None:
-        path = []
-    for key in b:
-        if key in a:
-            if isinstance(a[key], dict) and isinstance(b[key], dict):
-                merge_configs(a[key], b[key], path + [str(key)])
-                continue
-
-            if isinstance(a[key], list) and isinstance(b[key], list):
-                a[key] = list(set(a[key] + b[key]))
-            elif a[key] == b[key]:
-                pass  # same leaf value
-            else:
-                a[key] = b[key]
-        else:
-            a[key] = b[key]
-    return a
-
-
 def get_logger_config(loggers=()):
 
     filename = None
@@ -212,7 +194,7 @@ def get_logger_config(loggers=()):
         for k in loggers
     }
 
-    merge_configs(
+    merge_dicts(
         LOG_CONFIG,
         {
             "version": 1,

--- a/fps/main.py
+++ b/fps/main.py
@@ -18,6 +18,7 @@ def create_app():
     app = FastAPI(**fps_config.__dict__)
 
     load_routers(app)
+    Config.check_not_used_sections()
 
     return app
 

--- a/fps/utils.py
+++ b/fps/utils.py
@@ -42,3 +42,23 @@ def get_all_plugins_pkgs_names() -> Set[str]:
 
 def get_caller_plugin_name(stack_level: int = 1) -> str:
     return get_pkg_name(get_caller_module_name(stack_level + 1))
+
+
+def merge_dicts(a, b, path=None):
+    if path is None:
+        path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge_dicts(a[key], b[key], path + [str(key)])
+                continue
+
+            if isinstance(a[key], list) and isinstance(b[key], list):
+                a[key] = list(set(a[key] + b[key]))
+            elif a[key] == b[key]:
+                pass  # same leaf value
+            else:
+                a[key] = b[key]
+        else:
+            a[key] = b[key]
+    return a

--- a/plugins/helloworld/fps_helloworld/config.py
+++ b/plugins/helloworld/fps_helloworld/config.py
@@ -3,7 +3,9 @@ from fps.hooks import register_config, register_plugin_name
 
 
 class HelloConfig(PluginModel):
-    random: bool = True
+    random: bool = False
+    greeting: str = "hello"
+    count: int = 0
 
 
 c = register_config(HelloConfig)

--- a/plugins/helloworld/fps_helloworld/routes.py
+++ b/plugins/helloworld/fps_helloworld/routes.py
@@ -8,13 +8,17 @@ from fps.hooks import register_router
 from .config import HelloConfig
 
 r = APIRouter()
+config = Config(HelloConfig)
 
 
 @r.get("/hello")
 async def root(name: str = "world"):
-    if Config(HelloConfig).random:
-        name += str(random.randint(0, 10))
-    return {"message": name}
+    if config.random:
+        name = " ".join((name, str(random.randint(0, 250))))
+    else:
+        name = " ".join((name, str(config.count)))
+
+    return {"message": " ".join((config.greeting, name))}
 
 
 router = register_router(r)


### PR DESCRIPTION
Description
---

improve CLI parsing of plugins options
- warn about unused sections
- set default behavior to forbid extra keys in `PluginModel`
- consider option without value as a flag, set value at `true`

fix bug overwrite when passing multiple options on the same plugin
update helloworld example to allow testing fps features

Closes #14

Examples:

Multiple options of the same plugin / flag / unused config section warning
```
$ fps --helloworld.greeting=hi --auth.foo=bar --helloworld.random
(...)
[W 2021-09-10 14:31:04 fps] Configuration section(s) are not used by any plugin {'auth'}
```
Hill-formed option (missing plugin name or key name)
```
$ fps --helloworld.greeting=hi --auth=true
(...)
AttributeError: Plugin option must be of the form '<plugin-name>.<option>', got 'auth'
```
Hill-formed option (missing key name)
```
$ fps --helloworld.greeting.
(...)
ValueError: Hill-formed option key 'helloworld.greeting.'
```