### PR TITLE
Add testing fixtures

### DIFF
--- a/fps/config.py
+++ b/fps/config.py
@@ -46,7 +46,7 @@ class Config:
     _plugin2name: Dict[ModuleType, str] = {}
     _pkg2name: Dict[str, str] = {}
 
-    def __new__(cls, plugin_model: Type[PluginModel], file: str = None) -> PluginModel:
+    def __new__(cls, plugin_model: Type[PluginModel]) -> PluginModel:
         try:
             return cls._models[plugin_model][1]
         except KeyError:
@@ -56,7 +56,7 @@ class Config:
     @classmethod
     def register(
         cls,
-        config_name: ModuleType,
+        config_name: str,
         config_model: Type[PluginModel],
         force_update: bool = False,
     ):
@@ -183,3 +183,7 @@ class Config:
     def clear_names(cls):
         cls._plugin2name.clear()
         cls._pkg2name.clear()
+
+
+def get_config(model: Type[PluginModel]) -> PluginModel:
+    return Config(model)

--- a/fps/testing/fixtures.py
+++ b/fps/testing/fixtures.py
@@ -1,0 +1,24 @@
+import pytest
+from fastapi.testclient import TestClient
+
+from fps.main import create_app
+
+
+@pytest.fixture()
+def app():
+    yield create_app()
+
+
+@pytest.fixture()
+def config():
+    pass
+
+
+@pytest.fixture
+def dep_override(app, config):
+    pass
+
+
+@pytest.fixture()
+def client(app, dep_override):
+    yield TestClient(app)

--- a/plugins/helloworld/fps_helloworld/config.py
+++ b/plugins/helloworld/fps_helloworld/config.py
@@ -1,4 +1,5 @@
 from fps.config import PluginModel
+from fps.config import get_config as fps_get_config
 from fps.hooks import register_config, register_plugin_name
 
 
@@ -6,6 +7,10 @@ class HelloConfig(PluginModel):
     random: bool = False
     greeting: str = "hello"
     count: int = 0
+
+
+def get_config():
+    return fps_get_config(HelloConfig)
 
 
 c = register_config(HelloConfig)

--- a/plugins/helloworld/fps_helloworld/routes.py
+++ b/plugins/helloworld/fps_helloworld/routes.py
@@ -1,18 +1,16 @@
 import random
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from fps_helloworld.config import get_config
 
-from fps.config import Config
 from fps.hooks import register_router
 
-from .config import HelloConfig
-
 r = APIRouter()
-config = Config(HelloConfig)
 
 
 @r.get("/hello")
-async def root(name: str = "world"):
+async def root(name: str = "world", config=Depends(get_config)):
+
     if config.random:
         name = " ".join((name, str(random.randint(0, 250))))
     else:

--- a/plugins/helloworld/tests/conftest.py
+++ b/plugins/helloworld/tests/conftest.py
@@ -1,0 +1,27 @@
+import pytest
+from fps_helloworld.config import HelloConfig, get_config
+
+pytest_plugins = "fps.testing.fixtures"
+
+
+@pytest.fixture
+def greeting():
+    return "hello"
+
+
+@pytest.fixture
+def count():
+    return 0
+
+
+@pytest.fixture
+def config(greeting, count):
+    yield HelloConfig.parse_obj({"greeting": greeting, "count": count})
+
+
+@pytest.fixture
+def dep_override(app, config):
+    async def override_get_config():
+        return config
+
+    app.dependency_overrides[get_config] = override_get_config

--- a/plugins/helloworld/tests/test_routes.py
+++ b/plugins/helloworld/tests/test_routes.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def test_hello(client):
+    response = client.get("/hello")
+    assert response.status_code == 200
+    assert response.json() == {"message": "hello world 0"}
+
+
+@pytest.mark.parametrize("greeting", ("hello", "hi", "bonjour"))
+def test_greeting(greeting, client):
+    response = client.get("/hello")
+    assert response.status_code == 200
+    assert response.json() == {"message": f"{greeting} world 0"}
+
+
+@pytest.mark.parametrize("count", (10, 20))
+def test_count(count, client):
+    response = client.get("/hello")
+    assert response.status_code == 200
+    assert response.json() == {"message": f"hello world {count}"}


### PR DESCRIPTION
Description
---

Add testing fixtures
Use `fastAPI` dependency to pass config instead of using module variable
Use `fastAPI` `dependency_overrides` in testing fixture
Add examples in `helloworld` plugin
Remove unused optional argument `file` in `Config.__new__`
Fix wrong type hint